### PR TITLE
Change how we select if we search for the name or the type

### DIFF
--- a/PTA/itemapi.cpp
+++ b/PTA/itemapi.cpp
@@ -2362,13 +2362,17 @@ void ItemAPI::openWiki(std::shared_ptr<PItem> item)
 {
     QString itemName;
 
-    if (item->f_type.category == "gem" || item->f_type.category == "map" || item->f_type.category == "currency" || item->f_type.rarity == "Rare")
+    if (item->f_type.rarity == "Rare" )
     {
         itemName = QString::fromStdString(item->type);
     }
     else if (!item->name.empty())
     {
         itemName = QString::fromStdString(item->name);
+    }
+    else
+    {
+        itemName = QString::fromStdString(item->type);
     }
     itemName = itemName.replace(" ", "_");
     if (!QDesktopServices::openUrl(u_poewiki + itemName))


### PR DESCRIPTION
If we search for an item in the wiki, we should search for the item type
if it's a rare item and search for the item type for e.g. divination
cards.
We use the item type as a fallback, if it does not have a name.